### PR TITLE
Modify Hughes refraction used by NOAA

### DIFF
--- a/src/solposx/refraction/hughes.py
+++ b/src/solposx/refraction/hughes.py
@@ -67,7 +67,7 @@ def hughes(elevation, pressure=101325., temperature=12.):
     negative_elevation_mask = elevation <= -0.575
     Refract[negative_elevation_mask] = (-20.774 / TanEl)[negative_elevation_mask]
 
-    # Correct for temperature and pressure
+    # Correct for temperature and pressure and convert to degrees
     Refract *= (283/(273. + temperature)) * (pressure/101325.) / 3600.
 
     return Refract

--- a/src/solposx/solarposition/noaa.py
+++ b/src/solposx/solarposition/noaa.py
@@ -131,6 +131,8 @@ def noaa(times, latitude, longitude, delta_t=67.0):
     elevation = 90 - zenith
     refraction_correction = refraction.hughes(
         elevation=np.array(elevation), pressure=101325, temperature=10)
+    # Minor deviation of the refraction correction used by NOAA
+    refraction_correction[elevation > 85] = 0
 
     result = pd.DataFrame({
         'elevation': elevation,

--- a/src/solposx/solarposition/noaa.py
+++ b/src/solposx/solarposition/noaa.py
@@ -15,7 +15,9 @@ def noaa(times, latitude, longitude, delta_t=67.0):
     latitudes outside this the accuracy is 0.167 degrees.
 
     The NOAA algorithm uses by default the Hughes refraction model,
-    see ~:py:func:`solposx.refraction.hughes`.
+    see ~:py:func:`solposx.refraction.hughes`.  Note, that the implementation
+    deviates slightly from Hughes in that refraction is set to 0 for solar
+    elevation angles above 85 degrees.
 
     Parameters
     ----------

--- a/tests/test_solarposition.py
+++ b/tests/test_solarposition.py
@@ -478,3 +478,14 @@ def test_usno_gmst_option_value_error():
             latitude=50, longitude=10,
             gmst_option='not_an_option',
         )
+
+
+def test_noaa_refraction_85_degrees():
+    # Test that NOAA sets refraction to zero for solar
+    # elevation angles between (85 and 90]
+    # The below example has a solar elevation angle of 87.9
+    angles = noaa(
+        times=pd.date_range('2020-03-23 12', periods=1, tz='UTC'),
+        latitude=0, longitude=0,
+    )
+    assert angles['elevation'].iloc[0] == angles['apparent_elevation'].iloc[0]


### PR DESCRIPTION
Closes #27 

Modify the refraction calculated by the NOAA solar position algorithm. Specifically, refraction is set to zero for solar elevation angles above 85 degrees.