### PR TITLE
Improve equation formatting for `hughes`

### DIFF
--- a/src/solposx/refraction/hughes.py
+++ b/src/solposx/refraction/hughes.py
@@ -36,9 +36,9 @@ def hughes(elevation, pressure=101325., temperature=12.):
     .. math::
 
         \begin{align}
-        & \frac{58.1}{\text{tan}(el)} - \frac{0.07}{\text{tan}(el)^3} + \frac{8.6\cdot 10^{-5}}{tan(el)^5} \text{ for } 5° < el <= 90°\\
-        & el \cdot (-518.2 + el \cdot (103.4 + el \cdot (-12.79 + el \cdot 0.711))) + 1735 \text{ for } -0.575° < el <= 5°\\
-        & \frac{-20.774}{\text{tan}(el)} \text{ for } el <= -0.575°\\
+        5° < el \le 90° &: \quad \frac{58.1}{\text{tan}(el)} - \frac{0.07}{\text{tan}(el)^3} + \frac{8.6\cdot 10^{-5}}{\tan(el)^5}\\
+        -0.575° < el \le 5° &: \quad el \cdot (-518.2 + el \cdot (103.4 + el \cdot (-12.79 + el \cdot 0.711))) + 1735\\
+        el \le -0.575° &: \quad \frac{-20.774}{\text{tan}(el)}\\
         \end{align}
 
     where :math:`el` is the true (unrefracted) solar elevation angle.


### PR DESCRIPTION
Currently: 

<img width="758" height="298" alt="image" src="https://github.com/user-attachments/assets/2a58a46b-0ca3-4ab9-83d1-fdd75c594287" />

---

With this PR:

<img width="778" height="317" alt="image" src="https://github.com/user-attachments/assets/21ae5d83-5d2b-4174-845d-a875c333d7db" />
