### PR TITLE
BUILD: documentation link and Adam's email is Adam's email fixes in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
 all = ["solposx[optional,test,doc]"]
 
 [project.urls]
-# Documentation = "https://solposx.readthedocs.io"
+Documentation = "https://solposx.readthedocs.io"
 Issues = "https://github.com/assessingsolar/solposx/issues"
 Repository = "https://github.com/assessingsolar/solposx.git"
 Changelog = "https://github.com/assessingsolar/solposx/blob/main/docs/source/whatsnew.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,9 @@ where = ["src"]
 [project]
 name = "solposx"
 authors = [
-    {name = "Adam R. Jensen"},
+    {name = "Adam R. Jensen", email = "adam-r-j@hotmail.com"},
     {name = "Kevin S. Anderson"},
     {name = "Ioannis Sifnaios"},
-    {email = "adam-r-j@hotmail.com"},
 ]
 description = "solposx is a Python package for calculating solar position angles and comparing solar position algorithms."
 readme = "README.md"


### PR DESCRIPTION
This PR just makes to minor changes to the project metadada:
1. Makes Adam's name link to he, instead of to the three of you. So it's clear that it's not a shared email address.
    Following image @ https://pypi.org/project/solposx/
    <img width="648" height="301" alt="image" src="https://github.com/user-attachments/assets/5d58349c-c198-4c46-bafb-9b2bf1a0a4fa" />

3. Uncomments metadata documentation link
    Again, from PyPI, it is not shown
    <img width="310" height="286" alt="image" src="https://github.com/user-attachments/assets/109de0bd-bcac-4f69-9670-a714fab1224a" />
